### PR TITLE
Add modular booking widget skeleton

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "chime-booking-widget",
       "version": "0.0.0",
       "dependencies": {
+        "prop-types": "^15.8.1",
         "react": "^19.1.0",
         "react-dom": "^19.1.0"
       },
@@ -2115,7 +2116,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/js-yaml": {
@@ -2225,6 +2225,18 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/loose-envify": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^3.0.0 || ^4.0.0"
+      },
+      "bin": {
+        "loose-envify": "cli.js"
+      }
+    },
     "node_modules/lru-cache": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
@@ -2287,6 +2299,15 @@
       "integrity": "sha512-xxOWJsBKtzAq7DY0J+DTzuz58K8e7sJbdgwkbMWQe8UYB6ekmsQ45q0M/tJDsGaZmbC+l7n57UV8Hl5tHxO9uw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/optionator": {
       "version": "0.9.4",
@@ -2430,6 +2451,17 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/prop-types": {
+      "version": "15.8.1",
+      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
+      "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.4.0",
+        "object-assign": "^4.1.1",
+        "react-is": "^16.13.1"
+      }
+    },
     "node_modules/punycode": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -2460,6 +2492,12 @@
       "peerDependencies": {
         "react": "^19.1.0"
       }
+    },
+    "node_modules/react-is": {
+      "version": "16.13.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+      "license": "MIT"
     },
     "node_modules/react-refresh": {
       "version": "0.17.0",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "prop-types": "^15.8.1",
     "react": "^19.1.0",
     "react-dom": "^19.1.0"
   },

--- a/src/App.css
+++ b/src/App.css
@@ -1,42 +1,26 @@
-#root {
-  max-width: 1280px;
-  margin: 0 auto;
+.widget-wrapper {
   padding: 2rem;
+  font-family: sans-serif;
+}
+.service-card {
+  display: block;
+  padding: 1rem;
+  margin: 0.5rem 0;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  background: #f9f9f9;
+}
+.time-slot {
+  margin: 0.25rem;
+  padding: 0.5rem 1rem;
+}
+.booking-form > div {
+  margin-bottom: 1rem;
+}
+.payment-step {
   text-align: center;
 }
-
-.logo {
-  height: 6em;
-  padding: 1.5em;
-  will-change: filter;
-  transition: filter 300ms;
-}
-.logo:hover {
-  filter: drop-shadow(0 0 2em #646cffaa);
-}
-.logo.react:hover {
-  filter: drop-shadow(0 0 2em #61dafbaa);
-}
-
-@keyframes logo-spin {
-  from {
-    transform: rotate(0deg);
-  }
-  to {
-    transform: rotate(360deg);
-  }
-}
-
-@media (prefers-reduced-motion: no-preference) {
-  a:nth-of-type(2) .logo {
-    animation: logo-spin infinite 20s linear;
-  }
-}
-
-.card {
-  padding: 2em;
-}
-
-.read-the-docs {
-  color: #888;
+.confirmation {
+  padding: 1rem;
+  background: #e6ffe6;
 }

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,35 +1,10 @@
-import { useState } from 'react'
-import reactLogo from './assets/react.svg'
-import viteLogo from '/vite.svg'
+import WidgetShell from './components/WidgetShell.jsx'
 import './App.css'
 
-function App() {
-  const [count, setCount] = useState(0)
-
+export default function App() {
   return (
-    <>
-      <div>
-        <a href="https://vite.dev" target="_blank">
-          <img src={viteLogo} className="logo" alt="Vite logo" />
-        </a>
-        <a href="https://react.dev" target="_blank">
-          <img src={reactLogo} className="logo react" alt="React logo" />
-        </a>
-      </div>
-      <h1>Vite + React</h1>
-      <div className="card">
-        <button onClick={() => setCount((count) => count + 1)}>
-          count is {count}
-        </button>
-        <p>
-          Edit <code>src/App.jsx</code> and save to test HMR
-        </p>
-      </div>
-      <p className="read-the-docs">
-        Click on the Vite and React logos to learn more
-      </p>
-    </>
+    <div className="widget-wrapper">
+      <WidgetShell />
+    </div>
   )
 }
-
-export default App

--- a/src/components/BookingForm.jsx
+++ b/src/components/BookingForm.jsx
@@ -1,0 +1,28 @@
+import PropTypes from 'prop-types'
+import { useState } from 'react'
+
+export default function BookingForm({ onSubmit }) {
+  const [name, setName] = useState('')
+  const [email, setEmail] = useState('')
+
+  function handleSubmit(e) {
+    e.preventDefault()
+    onSubmit({ name, email })
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="booking-form">
+      <div>
+        <label>Name <input value={name} onChange={(e) => setName(e.target.value)} required /></label>
+      </div>
+      <div>
+        <label>Email <input type="email" value={email} onChange={(e) => setEmail(e.target.value)} required /></label>
+      </div>
+      <button type="submit">Continue</button>
+    </form>
+  )
+}
+
+BookingForm.propTypes = {
+  onSubmit: PropTypes.func.isRequired,
+}

--- a/src/components/Calendar.jsx
+++ b/src/components/Calendar.jsx
@@ -1,0 +1,17 @@
+import PropTypes from 'prop-types'
+
+export default function Calendar({ value, onChange }) {
+  return (
+    <div className="calendar-picker">
+      <label>
+        Date:
+        <input type="date" value={value} onChange={(e) => onChange(e.target.value)} />
+      </label>
+    </div>
+  )
+}
+
+Calendar.propTypes = {
+  value: PropTypes.string,
+  onChange: PropTypes.func.isRequired,
+}

--- a/src/components/Confirmation.jsx
+++ b/src/components/Confirmation.jsx
@@ -1,0 +1,15 @@
+import PropTypes from 'prop-types'
+
+export default function Confirmation({ booking }) {
+  return (
+    <div className="confirmation">
+      <h2>Booking Confirmed!</h2>
+      <p>{booking.service.name} on {booking.date} at {booking.time}</p>
+      <p>Thanks, {booking.customer.name}! A confirmation email will be sent to {booking.customer.email}.</p>
+    </div>
+  )
+}
+
+Confirmation.propTypes = {
+  booking: PropTypes.object.isRequired,
+}

--- a/src/components/Payment.jsx
+++ b/src/components/Payment.jsx
@@ -1,0 +1,19 @@
+import PropTypes from 'prop-types'
+
+export default function Payment({ onSuccess }) {
+  function handlePay() {
+    // pretend payment succeeded
+    onSuccess({ paymentIntentId: 'test' })
+  }
+
+  return (
+    <div className="payment-step">
+      <p>Payment step (placeholder)</p>
+      <button onClick={handlePay}>Pay Deposit</button>
+    </div>
+  )
+}
+
+Payment.propTypes = {
+  onSuccess: PropTypes.func.isRequired,
+}

--- a/src/components/ServiceList.jsx
+++ b/src/components/ServiceList.jsx
@@ -1,0 +1,19 @@
+import PropTypes from 'prop-types'
+
+export default function ServiceList({ services, onSelect }) {
+  return (
+    <div className="service-list">
+      {services.map((s) => (
+        <button key={s.id} className="service-card" onClick={() => onSelect(s)}>
+          <div className="service-name">{s.name}</div>
+          {s.duration && <div className="service-duration">{s.duration} mins</div>}
+        </button>
+      ))}
+    </div>
+  )
+}
+
+ServiceList.propTypes = {
+  services: PropTypes.arrayOf(PropTypes.object).isRequired,
+  onSelect: PropTypes.func.isRequired,
+}

--- a/src/components/TimeSlots.jsx
+++ b/src/components/TimeSlots.jsx
@@ -1,0 +1,16 @@
+import PropTypes from 'prop-types'
+
+export default function TimeSlots({ slots, onSelect }) {
+  return (
+    <div className="time-slots">
+      {slots.map((t) => (
+        <button key={t} className="time-slot" onClick={() => onSelect(t)}>{t}</button>
+      ))}
+    </div>
+  )
+}
+
+TimeSlots.propTypes = {
+  slots: PropTypes.arrayOf(PropTypes.string).isRequired,
+  onSelect: PropTypes.func.isRequired,
+}

--- a/src/components/WidgetShell.jsx
+++ b/src/components/WidgetShell.jsx
@@ -1,0 +1,75 @@
+import { useState } from 'react'
+import ServiceList from './ServiceList.jsx'
+import Calendar from './Calendar.jsx'
+import TimeSlots from './TimeSlots.jsx'
+import BookingForm from './BookingForm.jsx'
+import Payment from './Payment.jsx'
+import Confirmation from './Confirmation.jsx'
+
+const dummyServices = [
+  { id: 'svc1', name: 'Consultation', duration: 30 },
+  { id: 'svc2', name: 'Repair', duration: 60 },
+]
+
+const dummyTimes = ['09:00', '10:00', '11:00', '14:00']
+
+export default function WidgetShell() {
+  const [step, setStep] = useState('services')
+  const [service, setService] = useState(null)
+  const [date, setDate] = useState('')
+  const [time, setTime] = useState('')
+  const [customer, setCustomer] = useState(null)
+  const [booking, setBooking] = useState(null)
+
+  function handleServiceSelect(svc) {
+    setService(svc)
+    setStep('date')
+  }
+
+  function handleDateSelect(d) {
+    setDate(d)
+    setStep('time')
+  }
+
+  function handleTimeSelect(t) {
+    setTime(t)
+    setStep('form')
+  }
+
+  function handleFormSubmit(data) {
+    setCustomer(data)
+    setStep('payment')
+  }
+
+  function handlePaymentSuccess(pay) {
+    const b = {
+      service,
+      date,
+      time,
+      customer,
+      payment: pay,
+    }
+    setBooking(b)
+    setStep('confirm')
+  }
+
+  if (step === 'services') {
+    return <ServiceList services={dummyServices} onSelect={handleServiceSelect} />
+  }
+  if (step === 'date') {
+    return <Calendar value={date} onChange={handleDateSelect} />
+  }
+  if (step === 'time') {
+    return <TimeSlots slots={dummyTimes} onSelect={handleTimeSelect} />
+  }
+  if (step === 'form') {
+    return <BookingForm onSubmit={handleFormSubmit} />
+  }
+  if (step === 'payment') {
+    return <Payment onSuccess={handlePaymentSuccess} />
+  }
+  if (step === 'confirm') {
+    return <Confirmation booking={booking} />
+  }
+  return null
+}


### PR DESCRIPTION
## Summary
- replace default app with a new `WidgetShell` booking flow
- build modular components for service list, date picker, time slots
- add simple booking form, payment placeholder and confirmation screen
- add basic styles
- include prop-types dependency

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68423e78d2848321bed453e66724ca6e